### PR TITLE
Make wavelet_transform a writable attribute.

### DIFF
--- a/wavelets/transform.py
+++ b/wavelets/transform.py
@@ -367,6 +367,16 @@ class WaveletTransform(object):
 
     @property
     def wavelet_transform(self):
+        if not hasattr(self, '_wavelet_transform'):
+            return self.transform()
+        else:
+            return self._wavelet_transform
+
+    @wavelet_transform.setter
+    def wavelet_transform(self, value):
+        setattr(self, '_wavelet_transform', value)
+
+    def transform(self):
         """Calculate the wavelet transform."""
         widths = self.scales
 
@@ -375,12 +385,14 @@ class WaveletTransform(object):
         else:
             wavelet = self.wavelet.time
 
-        return self.cwt(self.anomaly_data,
-                        wavelet=wavelet,
-                        widths=widths,
-                        dt=self.dt,
-                        frequency=self.frequency,
-                        axis=self.axis)
+        self.wavelet_transform = self.cwt(self.anomaly_data,
+                                          wavelet=wavelet,
+                                          widths=widths,
+                                          dt=self.dt,
+                                          frequency=self.frequency,
+                                          axis=self.axis)
+
+        return self.wavelet_transform
 
     @property
     def wavelet_power(self):


### PR DESCRIPTION
That allows, for instance, reconstruction to be used with an altered wavelet_transform.

Example usage:

    def get_wt_nmfd(wav_path, wav_prefix, plot_prefix):
        fs, x = wavfile.read(wav_path)
        dt = 1.0/fs
        dj = 1.0/16.0
        eps = np.spacing(1)
        do_nmfd = True
        wav_max = 2.0**15 - 1.0

        wa = WaveletAnalysis(x, wavelet=Morlet(), dt=dt, dj=dj, unbias=False)
        # wavelet power spectrum
        power = wa.wavelet_power
        wt = copy.deepcopy(wa.wavelet_transform)
        xi = wa.reconstruction()

        nmfd = None
        if do_nmfd:
            nmfd = nmfdkl.NMFDKL(power, 5, 2*power.shape[0]/3)
            new_v = nmfd.nmfdkl(20, 10)
            denom = 1.0 / (new_v[:, :, -1] + eps)
            for r in xrange(new_v.shape[2] - 1):
                wa.wavelet_transform = copy.deepcopy(wt)
                wa.wavelet_transform *= new_v[:, :, r]*denom
                xi = wa.reconstruction()