### PR TITLE
Changed import of factorial for SciPy>1.0

### DIFF
--- a/wavelets/transform.py
+++ b/wavelets/transform.py
@@ -92,6 +92,7 @@ def cwt_time(data, wavelet, widths, dt, axis):
     # compute in time
     slices = [None for _ in data.shape]
     slices[axis] = slice(None)
+    slices = tuple(slices)
     for ind, width in enumerate(widths):
         # number of points needed to capture wavelet
         M = 10 * width / dt

--- a/wavelets/wavelets.py
+++ b/wavelets/wavelets.py
@@ -5,7 +5,7 @@ import scipy
 import scipy.signal
 import scipy.optimize
 import scipy.special
-from scipy.misc import factorial
+from scipy.special import factorial
 
 __all__ = ['Morlet', 'Paul', 'DOG', 'Ricker', 'Marr', 'Mexican_hat']
 

--- a/wavelets/wavelets.py
+++ b/wavelets/wavelets.py
@@ -186,7 +186,12 @@ class Paul(object):
         return 4 * np.pi * s / (2 * self.m + 1)
 
     def scale_from_period(self, period):
-        raise NotImplementedError()
+        """
+        Compute the scale from the fourier period.
+        Returns the scale
+        """
+        # Solve 4 * np.pi * scale / (2 * m + 1) for s
+        return period * (2 * self.m + 1) / (4 * np.pi)        
 
     # Frequency representation
     def frequency(self, w, s=1.0):
@@ -313,7 +318,12 @@ class DOG(object):
         return 2 * np.pi * s / (self.m + 0.5) ** .5
 
     def scale_from_period(self, period):
-        raise NotImplementedError()
+        """
+        Compute the scale from the fourier period.
+        Returns the scale
+        """
+        # Solve 2 * np.pi * s / (np.sqrt(m + 1/2)) for s
+        return period * np.sqrt(self.m + 0.5) / (2 * np.pi)
 
     def frequency(self, w, s=1.0):
         """Frequency representation of derivative of Gaussian.


### PR DESCRIPTION
The alias scipy.misc.factorial is deprecated sicne scipy 1.0. Instead,
scipy.special.factorial should be used.